### PR TITLE
Fix single object placement bug in Battle scene.

### DIFF
--- a/LoganToga2/Battle.cpp
+++ b/LoganToga2/Battle.cpp
@@ -2724,21 +2724,8 @@ void Battle::handleBuildTargetSelection()
 
 	if (const auto index = ToIndex(Cursor::PosF(), columnQuads, rowQuads))
 	{
-		if (ToTile(*index, N).leftClicked() && longBuildSelectTragetId != -1)
-		{
-			IsBuildSelectTraget = false;
-			IsBuildMenuHome = false;
-
-			Unit& cu = GetCU(longBuildSelectTragetId);
-			cu.currentTask = UnitTask::MovingToBuild;
-			cu.orderPosiLeft = Cursor::PosF().movedBy(-(cu.yokoUnit / 2), -(cu.TakasaUnit / 2));
-			cu.orderPosiLeftLast = Cursor::PosF();
-			cu.vecMove = (cu.orderPosiLeft - cu.nowPosiLeft).normalized();
-			cu.moveState = moveState::MoveAI;
-			cu.IsSelect = false;
-
-			IsBattleMove = false;
-			abortMyUnits = false;
+		if (ToTile(*index, N).leftClicked() && longBuildSelectTragetId != -1) {
+			processBuildOnTiles({ *index });
 		}
 		// 右クリックドラッグによる範囲選択
 		if (MouseR.up() && longBuildSelectTragetId != -1) {


### PR DESCRIPTION
In the `handleBuildTargetSelection` function, the logic for a single left-click was different from the logic for a right-click drag. The left-click path incorrectly tried to dispatch a unit to move to the build site, which failed for static objects like facilities or barbed wire.

This change unifies the logic. Now, a single left-click on a tile is treated as a build action for that specific tile, calling the existing `processBuildOnTiles` function. This makes single-click placement behave consistently with drag-selection placement and resolves the bug.