### PR TITLE
Fix deadlocks in battle loops

### DIFF
--- a/LoganToga2/Battle.cpp
+++ b/LoganToga2/Battle.cpp
@@ -3052,7 +3052,6 @@ Co::Task<void> Battle::mainLoop()
 		updateBuildQueue();
 		try {
 			// 移動処理 - 安全なインデックスベースループ
-			std::scoped_lock lock(classBattle.unitListMutex);
 			for (size_t groupIndex = 0; groupIndex < classBattle.listOfAllUnit.size(); ++groupIndex)
 			{
 				auto& item = classBattle.listOfAllUnit[groupIndex];

--- a/LoganToga2/Battle001.cpp
+++ b/LoganToga2/Battle001.cpp
@@ -1687,7 +1687,6 @@ void Battle001::updateUnitHealthBars()
 void Battle001::updateUnitMovements()
 {
 	//移動処理
-	std::scoped_lock lock(classBattleManage.unitListMutex);
 	for (auto& item : classBattleManage.listOfAllUnit)
 	{
 		for (auto& itemUnit : item.ListClassUnit)


### PR DESCRIPTION
Removed coarse-grained `std::scoped_lock`s on `unitListMutex` from the main loop in `Battle.cpp` and from `updateUnitMovements` in `Battle001.cpp`.

These locks were held for a long duration and were acquired before another lock (`aiRootMutex`), creating a high risk of deadlocks with concurrent AI threads. Removing the outer locks breaks the potential for circular waits and should resolve the `resource deadlock would occur` error.