### PR TITLE
refactor(battle): Improve readability of Battle001

### DIFF
--- a/LoganToga2/Battle001.h
+++ b/LoganToga2/Battle001.h
@@ -168,6 +168,8 @@ private:
 	Co::Task<> checkCancelSelectionByUIArea();
 	void handleBuildMenuSelectionA();
 	void processUnitBuildMenuSelection(Unit& unit);
+	void handleCarrierStoreCommand(Unit& unit);
+	void handleCarrierReleaseCommand(Unit& unit);
 	void handleUnitAndBuildingSelection();
 	void processClickSelection();
 	Optional<long long> findClickedBuildingId() const;
@@ -384,7 +386,7 @@ private:
 	bool tryActivateSkillOnTargetGroup(Array<ClassHorizontalUnit>& target_groups, const Vec2& attacker_pos, Unit& attacker, Skill& skill, Array<ClassExecuteSkills>& executed_skills);
 	bool isTargetInRange(const Unit& attacker, const Unit& target, const Skill& skill) const;
 	ClassExecuteSkills createSkillExecution(Unit& attacker, const Unit& target, const Skill& skill);
-	void ColliderCheck(RectF rrr, ClassBullets& target, ClassExecuteSkills& loop_Battle_player_skills, Array<int32>& arrayNo, Array<ClassHorizontalUnit>& chu);
+	void ColliderCheck(RectF skillHitbox, ClassBullets& target, ClassExecuteSkills& loop_Battle_player_skills, Array<int32>& arrayNo, Array<ClassHorizontalUnit>& chu);
 	void ColliderCheckHeal(RectF rrr, ClassBullets& target, ClassExecuteSkills& loop_Battle_player_skills, Array<int32>& arrayNo, Unit* itemTarget);
 	void CalucDamage(Unit& itemTarget, double strTemp, ClassExecuteSkills& ces);
 	bool ProcessCollid(bool& bombCheck, Array<int32>& arrayNo, ClassBullets& target, ClassExecuteSkills& loop_Battle_player_skills, Unit& itemTarget);


### PR DESCRIPTION
This commit performs several small, safe refactorings on the large Battle001 class to improve its readability and maintainability, as per the initial request.

The following changes were made:

- **Extract Carrier Command Handlers:** The logic for handling "Carrier" and "releaseAll" commands was extracted from the monolithic `processUnitBuildMenuSelection` function into two new private methods: `handleCarrierStoreCommand` and `handleCarrierReleaseCommand`. This simplifies the original function and isolates distinct logic. A bug was also fixed where these commands would fall through to the build queue logic.

- **Remove Dead Code:** Several large blocks of commented-out legacy code were removed from the `updateResourceIncome`, `drawTileMap`, and `drawFog` functions. This cleans up the code and removes confusion.

- **Improve Naming:** The obscure parameter `rrr` in the `ColliderCheck` function was renamed to the more descriptive `skillHitbox` in both the declaration and definition.